### PR TITLE
bluebird 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": ">=0.12.0"
   },
   "dependencies": {
-    "bluebird": "2.10.0",
+    "bluebird": "3.1.1",
     "lodash": "3.10.1",
     "helfer": "0.1.0"
   },

--- a/test/computation-example-async.coffee
+++ b/test/computation-example-async.coffee
@@ -5,17 +5,17 @@ hinoki = require '../lib/hinoki'
 
 factories =
   count: (xs) ->
-    Promise.delay(xs.length, 100)
+    Promise.delay(100, xs.length)
   mean: (xs, count) ->
     reducer = (acc, x) ->
       acc + x
-    Promise.delay(xs.reduce(reducer, 0) / count, 100)
+    Promise.delay(100, xs.reduce(reducer, 0) / count)
   meanOfSquares: (xs, count) ->
     reducer = (acc, x) ->
       acc + x * x
-    Promise.delay(xs.reduce(reducer, 0) / count, 100)
+    Promise.delay(100, xs.reduce(reducer, 0) / count)
   variance: (mean, meanOfSquares) ->
-    Promise.delay(meanOfSquares - mean * mean, 100)
+    Promise.delay(100, meanOfSquares - mean * mean)
 
 test 'ask for count', (t) ->
   source = hinoki.source factories

--- a/test/integration.coffee
+++ b/test/integration.coffee
@@ -170,13 +170,13 @@ test 'a factory is called no more than once', (t) ->
   source = hinoki.source
     a: (b, c) ->
       callsTo.a++
-      Promise.delay(b + c, 40)
+      Promise.delay(40, b + c)
     b: (d) ->
       callsTo.b++
-      Promise.delay(d + 1, 20)
+      Promise.delay(20, d + 1)
     c: (d) ->
       callsTo.c++
-      Promise.delay(d + 2, 30)
+      Promise.delay(30, d + 2)
     d: ->
       callsTo.d++
       Promise.delay(10, 10)
@@ -196,7 +196,7 @@ test 'promises awaiting resolution are cached and reused', (t) ->
   source = hinoki.source
     a: ->
       # here a new object is created
-      Promise.delay object, 10
+      Promise.delay 10, object
   lifetime = {}
 
   p1 = hinoki(source, lifetime, 'a')
@@ -226,14 +226,14 @@ test 'all dependent promises are created without interleaving', (t) ->
       t.ok lifetime.a?
       t.ok lifetime.b?
       t.ok lifetime.c?
-      Promise.delay a, 10
+      Promise.delay 10, a
     b: (a) ->
       t.ok lifetime.b?
       t.ok lifetime.c?
-      Promise.delay {a: a}, 10
+      Promise.delay 10, {a: a}
     c: (b) ->
       t.ok lifetime.c?
-      Promise.delay {b: b}, 10
+      Promise.delay 10, {b: b}
   lifetime = {}
 
   promiseCWithCleanup = hinoki(source, lifetime, 'c')


### PR DESCRIPTION
- [x] fix Promise.delay arguments order - was (value, ms) is (ms, value) as of 3.x
- [ ] fix [test/debug.coffee](test/debug.coffee) - fails at bravo_charlie
